### PR TITLE
Fix makefile hanging on pdflatex errors

### DIFF
--- a/Tutorials/LaTeX/Makefile
+++ b/Tutorials/LaTeX/Makefile
@@ -6,7 +6,7 @@ all: $(FILES_BASE)
 
 $(FILES_BASE): %:
 	@echo Making $@
-	@cd src; pdflatex -shell-escape $@.tex > /dev/null; pdflatex -shell-escape $@.tex > /dev/null; pdflatex -shell-escape $@.tex > /dev/null # wtf, latex
+	-@cd src; pdflatex -shell-escape -interaction nonstopmode $@.tex > /dev/null # wtf, latex
 	@mv -f src/$@.pdf pdf/
 	@rm -f src/*.aux src/*.log src/*.toc src/*.out src/content/*.aux
 	@rm -rf src/_minted-*


### PR DESCRIPTION
Since the pdflatex output is blackholed, when a pdflatex error occurs the make process just hangs without any indication of a failure or the prompt being displayed. So this is a hacky fix for that.